### PR TITLE
FF to AWS 3.0 provider upgrades 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -173,6 +173,7 @@ module "autoscale_group" {
   enabled    = local.enabled
   namespace  = module.this.namespace
   stage      = module.this.stage
+  environment = module.this.environment
   name       = module.this.name
   delimiter  = module.this.delimiter
   attributes = module.this.attributes
@@ -193,6 +194,7 @@ module "autoscale_group" {
   user_data_base64 = base64encode(join("", data.template_file.userdata.*.rendered))
 
   instance_type                           = var.instance_type
+  launch_template_version                 = var.launch_template_version
   subnet_ids                              = var.subnet_ids
   min_size                                = var.min_size
   max_size                                = var.max_size

--- a/main.tf
+++ b/main.tf
@@ -167,8 +167,8 @@ data "aws_iam_instance_profile" "default" {
 }
 
 module "autoscale_group" {
-  source  = "cloudposse/ec2-autoscale-group/aws"
-  version = "0.7.2"
+
+  source = "github.com/SkywardIO/terraform-aws-ec2-autoscale-group.git?ref=feature/update_label_module"
 
   enabled    = local.enabled
   namespace  = module.this.namespace

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "image_id" {
   default     = ""
 }
 
+variable "launch_template_version" {
+  description = "Specifies the launch template version to be used."
+  type        = string
+  default     = "$Latest"
+}
+
 variable "use_custom_image_id" {
   type        = bool
   description = "If set to `true`, will use variable `image_id` for the EKS workers inside autoscaling group"


### PR DESCRIPTION
Goodies that used to live in [adamcrews/terraform-aws-eks-workers//feature/relax_validation_rules](https://github.com/adamcrews/terraform-aws-eks-workers/tree/feature/relax_validation_rules) and dealt with `cloudposse/terraform-aws-ec2-autoscale-group` [ISSUE #18](https://github.com/cloudposse/terraform-aws-ec2-autoscale-group/issues/18)


Also points to SkywardIO fork of `cloudposse/terraform-aws-ec2-autoscale-group` that has upstream [contribution here](https://github.com/cloudposse/terraform-aws-ec2-autoscale-group/pull/41) so that once that is merged to cloudposse, we won't have much work (we can just point to cloudposse tag as it was in the commented code below).